### PR TITLE
fix posible bug in onClick event handle, must be async/await

### DIFF
--- a/src/components/ListGifs.jsx
+++ b/src/components/ListGifs.jsx
@@ -5,6 +5,8 @@ const sharedOptions = async (shareData) => {
 	try {
 		await navigator.share({url:shareData});
 	} catch (err) {
+		console.error(err)
+		return;
 	}
 };
 
@@ -16,7 +18,7 @@ const ListGifs = ({ listadeGifs }) => {
 					<div key={item.id} className={styles.container__gifs}>
 						<img src={item.url} alt={item.title} />
 						<p>{item.title}</p>
-						<button onClick={() => sharedOptions(item.url)} type="button">
+						<button onClick={async() => await sharedOptions(item.url)} type="button">
 							Compartir
 						</button>
 					</div>


### PR DESCRIPTION
El control de un evento asynchrono requiere un async/await para mejor control de la ejecucion y asegurar una salida en caso de error para liberar la memoria por eso es necesario pasarle un async y tener una salida en el catch